### PR TITLE
Allow custom scalars in query arguments

### DIFF
--- a/src/Query.fs
+++ b/src/Query.fs
@@ -416,13 +416,14 @@ let rec validateFieldArgument (fieldName:string) (argument: GraphqlFieldArgument
             match foundVariable with
             | None -> [ QueryError.UsedNonDeclaredVariable(fieldName, argument.name, variableName) ]
             | Some variable ->
-                match variable.variableType with
-                | GraphqlVariableType.NonNull (GraphqlVariableType.Ref "ID") when scalar = GraphqlScalar.ID -> [ ]
-                | GraphqlVariableType.NonNull (GraphqlVariableType.Ref "String") when scalar = GraphqlScalar.String || scalar = GraphqlScalar.ID ->  [ ]
-                | GraphqlVariableType.NonNull (GraphqlVariableType.Ref "Int") when scalar = GraphqlScalar.Int -> [ ]
-                | GraphqlVariableType.NonNull (GraphqlVariableType.Ref "Float") when scalar = GraphqlScalar.Float ->  [ ]
-                | GraphqlVariableType.NonNull (GraphqlVariableType.Ref "Boolean") when scalar = GraphqlScalar.Boolean -> [ ]
-                | otherVariableType ->
+                match (variable.variableType, scalar) with
+                | (GraphqlVariableType.NonNull (GraphqlVariableType.Ref "ID"), GraphqlScalar.ID)
+                | (GraphqlVariableType.NonNull (GraphqlVariableType.Ref "String"), (GraphqlScalar.String | GraphqlScalar.ID))
+                | (GraphqlVariableType.NonNull (GraphqlVariableType.Ref "Int"), GraphqlScalar.Int)
+                | (GraphqlVariableType.NonNull (GraphqlVariableType.Ref "Float"), GraphqlScalar.Float)
+                | (GraphqlVariableType.NonNull (GraphqlVariableType.Ref "Boolean"), GraphqlScalar.Boolean)
+                | (_, GraphqlScalar.Custom _) -> [ ]
+                | (otherVariableType, _) ->
                     [
                         QueryError.ArgumentAndVariableTypeMismatch(fieldName, argument.name, formatFieldArgumentType argumentType , variableName, formatVariableType otherVariableType)
                     ]


### PR DESCRIPTION
Hi! I had trouble using latest Snowflaqe with my Hasura-generated schema due to its use of custom `uuid` scalars instead of built-in `ID` scalar (https://github.com/hasura/graphql-engine/issues/3578). 

Example mutation:
```gql
mutation StartSessionMutation($sessionId: uuid!, $startedAt: timestamptz!) {
  update_session_by_pk(
    pk_columns: { session_id: $sessionId }
    _set: { started_at: $startedAt }
  ) {
    session_id
  }
}
```

With this change custom scalar arguments correctly appear as `string` in `InputVariables` instead of throwing the following error:

```
Field pk_columns contains type mismatch for argument session_id of type uuid! which references variable $sessionId of type uuid!
```

