### PR TITLE
Add an option to return Task from async F# client functions instead of Async

### DIFF
--- a/src/Types.fs
+++ b/src/Types.fs
@@ -9,6 +9,11 @@ type OutputTarget =
     | Shared
 
 [<RequireQualifiedAccess>]
+type AsyncReturnType =
+    | Async
+    | Task
+
+[<RequireQualifiedAccess>]
 type GraphqlScalar =
     | ID
     | Int


### PR DESCRIPTION
Refs #31 - adds an 'asyncReturnType' option to the config which, when set to 'task' uses Ply to generate F# client functions that return Task instead of Async.

This is the same change as the commit I linked from #31, but with the suggested changes to case sensitivity in the 'async' string and additional piece of validation to make it an error to specify usage of tasks in Fable targets.