### PR TITLE
.NET 6 SDK, Fantomas 5, GitHub Schema updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 image:
-- Visual Studio 2019
 - Visual Studio 2022
 - Ubuntu
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,16 @@
+image:
+- Visual Studio 2019
+- Visual Studio 2022
+- Ubuntu
 init:
   - git config --global core.autocrlf input
-
 build:
   verbosity: detailed
-
-install:
-  # install latest dotnet 5
-  - cmd: choco install dotnet
-
-os: Visual Studio 2019
-
+before_build:
+  - dotnet --list-sdks
+  - dotnet --version
 build_script:
-  - cmd: dotnet run --project ./tests/Snowflaqe.Tests.fsproj
-  - cmd: dotnet restore ./build/Snowflaqe.Build.fsproj
-  - cmd: dotnet run --project ./build/Snowflaqe.Build.fsproj -- integration
-
+  - dotnet run --project ./tests/Snowflaqe.Tests.fsproj
+  - dotnet restore ./build/Snowflaqe.Build.fsproj
+  - dotnet run --project ./build/Snowflaqe.Build.fsproj -- integration
 test: off

--- a/build/Program.fs
+++ b/build/Program.fs
@@ -18,7 +18,7 @@ let src = path [ solutionRoot; "src" ]
 let tests = path [ solutionRoot; "tests" ]
 let tasks = path [ solutionRoot; "tasks" ]
 
-let [<Literal>] TargetFramework = "netcoreapp3.1"
+let [<Literal>] TargetFramework = "net6.0"
 
 let test() =
     if Shell.Exec(Tools.dotnet, "run", tests) <> 0
@@ -110,29 +110,29 @@ let publishTasks() =
         failwith "Building Snowflaqe.Tasks failed"
 
 let buildCraftSchema() =
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ../samples/craft-cms/snowflaqe.json --generate", path [ solutionRoot; "src" ]) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ../samples/craft-cms/snowflaqe.json --generate", path [ solutionRoot; "src" ]) <> 0 then
         failwith "Running Fable generation failed"
     else
         if Shell.Exec(Tools.dotnet, "build", path [ solutionRoot; "samples"; "craft-cms"; "output" ]) <> 0
         then failwith "Could not build generated CraftCMS"
 
-let buildGitHub() =
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ../samples/github/snowflaqe.json --generate", path [ solutionRoot; "src" ]) <> 0
-    then failwith "Failed to generate GitHub client"
-    elif Shell.Exec(Tools.dotnet, "build GitHub.fsproj", path [ solutionRoot; "samples"; "github"; "output" ]) <> 0
-    then failwith "Failed to build the generated GitHub project"
+let buildGithub() =
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ../samples/github/snowflaqe.json --generate", path [ solutionRoot; "src" ]) <> 0
+    then failwith "Failed to generate Github client"
+    elif Shell.Exec(Tools.dotnet, "build Github.fsproj", path [ solutionRoot; "samples"; "github"; "output" ]) <> 0
+    then failwith "Failed to build the generated Github project"
 
-let buildGitHubDotNet() =
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ../samples/github/snowflaqe-dot-net.json --generate", path [ solutionRoot; "src" ]) <> 0
-    then failwith "Failed to generate GitHub client"
-    elif Shell.Exec(Tools.dotnet, "build GitHub.Data.GraphQLClient.fsproj", path [ solutionRoot; "samples"; "github"; "output" ]) <> 0
-    then failwith "Failed to build the generated GitHub project"
+let buildGithubDotNet() =
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ../samples/github/snowflaqe-dot-net.json --generate", path [ solutionRoot; "src" ]) <> 0
+    then failwith "Failed to generate Github client"
+    elif Shell.Exec(Tools.dotnet, "build Github.Data.GraphQLClient.fsproj", path [ solutionRoot; "samples"; "github"; "output" ]) <> 0
+    then failwith "Failed to build the generated Github project"
 
-let buildGitHubFable() =
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ../samples/github/snowflaqe-fable.json --generate", path [ solutionRoot; "src" ]) <> 0
-    then failwith "Failed to generate GitHub client"
-    elif Shell.Exec(Tools.dotnet, "build GitHub.Data.GraphQLClient.fsproj", path [ solutionRoot; "samples"; "github"; "output" ]) <> 0
-    then failwith "Failed to build the generated GitHub project"
+let buildGithubFable() =
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ../samples/github/snowflaqe-fable.json --generate", path [ solutionRoot; "src" ]) <> 0
+    then failwith "Failed to generate Github client"
+    elif Shell.Exec(Tools.dotnet, "build Github.Data.GraphQLClient.fsproj", path [ solutionRoot; "samples"; "github"; "output" ]) <> 0
+    then failwith "Failed to build the generated Github project"
 
 let generateTasksUsings (targets: MSBuildTarget seq) =
     targets
@@ -159,7 +159,7 @@ let generateProjectFile (imports: string seq) (defaultTargets: string option) (t
                 yield! imports |> Seq.map (fun path -> MSBuildXElement.Import(path) :> obj)
                 yield XElement.ofStringName("PropertyGroup",
                         XElement.ofStringName("OutputType", "Exe"),
-                        XElement.ofStringName("TargetFramework", "netcoreapp3.1")) :> obj
+                        XElement.ofStringName("TargetFramework", "net6.0")) :> obj
                 yield! targets |> Seq.map (fun target -> MSBuildXElement.Target(target) :> obj)
             }))
 
@@ -168,11 +168,11 @@ let generateProjectFileForTask (targetFrameworks : string list) (package :MSBuil
     let packageReferences = [
         {
             Name = "Snowflaqe.Tasks"
-            Version = "1.0.0"
+            Version = Program.SnowflaqeTasksVersion
             PrivateAssets = ValueSome "all"
             IncludeAssets = ValueSome "build"
         };
-        createPackageReference "FSharp.Control.FusionTasks" "2.4.0";
+        createPackageReference "FSharp.Control.FusionTasks" "2.6.0";
         createPackageReference "FSharp.SystemTextJson" Program.FSharpSystemTextJsonVersion;
         createPackageReference "System.Net.Http.Json" Program.SystemNetHttpJsonVersion;
     ]
@@ -185,7 +185,7 @@ let generateProjectFileForTask (targetFrameworks : string list) (package :MSBuil
                 yield XElement.ofStringName("PropertyGroup",
                         XElement.ofStringName("OutputType", "Exe"),
                         match targetFrameworks with
-                        | [] -> XElement.ofStringName("TargetFramework", "netcoreapp3.1")
+                        | [] -> XElement.ofStringName("TargetFramework", "net6.0")
                         | [head] -> XElement.ofStringName("TargetFramework", head)
                         | frameworks -> XElement.ofStringName("TargetFrameworks", frameworks |> String.concat(";"))
                 ) :> obj
@@ -216,7 +216,7 @@ let createProjectFileAndRun imports (projectFileName : string) =
 let createProjectFileForTaskAndRun (directory: string) (project : string) (package :MSBuildPackageReference list) (schema : string) (target : string) (queries : string) =
     let projectFileName = project + ".fsproj"
     let project = generateProjectFileForTask
-                    [ "netcoreapp3.1" ]
+                    [ "net6.0" ]
                     package
                     project
                     schema
@@ -225,14 +225,14 @@ let createProjectFileForTaskAndRun (directory: string) (project : string) (packa
     project.WriteTo (path [ directory; projectFileName ])
 
     if Shell.Exec(Tools.dotnet, $"build {projectFileName}", src) <> 0 then
-        failwith $"Running {projectFileName} generation failed"
+        failwith $"Running {projectFileName} for task generation failed"
     Shell.Exec(Tools.dotnet, "clean Snowflaqe.fsproj -v q", src) |> ignore
 
 
 let createMultiFrameworkProjectFileForTaskAndRun (directory: string) (project : string)  (packages :MSBuildPackageReference list) (schema : string) (target : string) (queries : string) =
     let projectFileName = project + ".fsproj"
     let project = generateProjectFileForTask
-                    [ "netcoreapp3.1"; "net5.0" ]
+                    [ "netcoreapp3.1"; "net6.0" ]
                     packages
                     project
                     schema
@@ -247,7 +247,7 @@ let createMultiFrameworkProjectFileForTaskAndRun (directory: string) (project : 
 let createProjectFileAndRebuild (directory: string) (project : string) (packages :MSBuildPackageReference list) (schema: string) (target: string) (queries: string) =
     let projectFileName = project + ".fsproj"
     let project = generateProjectFileForTask
-                    [ "netcoreapp3.1" ]
+                    [ "net6.0" ]
                     packages
                     project
                     schema
@@ -264,7 +264,7 @@ let tasksIntegration() =
     let generateGQLClientTask =
         { Name = "GenerateGraphQLClient"
           FullName = "Snowflaqe.Tasks.GenerateGraphQLClient"
-          AssemblyFile = path [ solutionRoot; "tasks"; "bin"; "Release"; "netcoreapp3.1"; "Snowflaqe.Tasks.dll" ]
+          AssemblyFile = path [ solutionRoot; "tasks"; "bin"; "Release"; "net6.0"; "Snowflaqe.Tasks.dll" ]
           Parameters =
             seq {
                 KeyValuePair("Output", path [ solutionRoot; "src"; "output"] :> obj)
@@ -281,7 +281,7 @@ let tasksIntegration() =
             Tasks = (generateGQLClientTask |> Seq.singleton) } |> Seq.singleton)
         (path [ solutionRoot; "src"; "SpotifyWithTasks.fsproj"])
 
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config snowflaqe-props-task.json --generate", src) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config snowflaqe-props-task.json --generate", src) <> 0 then
         failwith "Running Fable props generation failed"
 
     createProjectFileAndRebuild
@@ -295,7 +295,7 @@ let tasksIntegration() =
         "fable"
         "queries"
 
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ./snowflaqe-fsharp-props-task.json --generate", src) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ./snowflaqe-fsharp-props-task.json --generate", src) <> 0 then
         failwith "Running FSharp props generation failed"
 
     createProjectFileAndRebuild
@@ -306,7 +306,7 @@ let tasksIntegration() =
         "fsharp"
         "queries"
 
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ./snowflaqe-shared-props-task.json --generate", src) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ./snowflaqe-shared-props-task.json --generate", src) <> 0 then
         failwith "Running Shared props generation failed"
 
     createProjectFileAndRebuild src
@@ -334,7 +334,7 @@ let multiFrameworkTasksIntegration() =
     let generateGQLClientTask =
         { Name = "GenerateGraphQLClient"
           FullName = "Snowflaqe.Tasks.GenerateGraphQLClient"
-          AssemblyFile = path [ solutionRoot; "tasks"; "bin"; "Release"; "netcoreapp3.1"; "Snowflaqe.Tasks.dll" ]
+          AssemblyFile = path [ solutionRoot; "tasks"; "bin"; "Release"; "net6.0"; "Snowflaqe.Tasks.dll" ]
           Parameters =
             seq {
                 KeyValuePair("Output", path [ solutionRoot; "src"; "output"] :> obj)
@@ -351,7 +351,7 @@ let multiFrameworkTasksIntegration() =
             Tasks = (generateGQLClientTask |> Seq.singleton) } |> Seq.singleton)
         (path [ solutionRoot; "src"; "SpotifyWithTasks.fsproj"])
 
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config snowflaqe-props-task.json --generate", src) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config snowflaqe-props-task.json --generate", src) <> 0 then
         failwith "Running Fable props generation failed"
 
     createMultiFrameworkProjectFileForTaskAndRun
@@ -365,7 +365,7 @@ let multiFrameworkTasksIntegration() =
         "fable"
         "queries"
 
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ./snowflaqe-fsharp-props-task.json --generate", src) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ./snowflaqe-fsharp-props-task.json --generate", src) <> 0 then
         failwith "Running FSharp props generation failed"
 
     createMultiFrameworkProjectFileForTaskAndRun
@@ -379,7 +379,7 @@ let multiFrameworkTasksIntegration() =
         "fsharp"
         "queries"
 
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ./snowflaqe-shared-props-task.json --generate", src) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ./snowflaqe-shared-props-task.json --generate", src) <> 0 then
         failwith "Running Shared props generation failed"
 
     createMultiFrameworkProjectFileForTaskAndRun
@@ -404,7 +404,7 @@ let multiFrameworkTasksIntegration() =
         "queries"
 
 let generate config =
-    Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --config ./{config} --generate", src)
+    Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --config ./{config} --generate", src)
 
 let propsIntegration() =
     Console.WriteLine "Generating Fable props"
@@ -477,7 +477,7 @@ let buildFSharpWithSharedTasks() =
 
 let fsprojIntegration() =
     Console.WriteLine "Generating Fable project"
-    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} -p Snowflaqe.fsproj -- --generate", path [ solutionRoot; "src" ]) <> 0 then
+    if Shell.Exec(Tools.dotnet, $"run -f {TargetFramework} --project Snowflaqe.fsproj -- --generate", path [ solutionRoot; "src" ]) <> 0 then
         failwith "Running Fable generation failed"
 
     if Shell.Exec(Tools.dotnet, "build", path [ solutionRoot; "src"; "output" ]) <> 0
@@ -506,10 +506,10 @@ let fsprojIntegration() =
         buildFSharpShared()
         buildFSharpWithSharedTasks()
         buildFSharpWithSystemTextJson()
-        buildGitHub()
+        buildGithub()
         buildCraftSchema()
-        buildGitHubDotNet()
-        buildGitHubFable()
+        buildGithubDotNet()
+        buildGithubFable()
 
 let clear() =
     File.Delete(path [ solutionRoot; "src"; "nuget.config" ])
@@ -550,9 +550,9 @@ let main (args: string[]) =
             fsprojIntegration()
             clear()
         | [| "build-craft" |] -> buildCraftSchema()
-        | [| "build-github" |] -> buildGitHub()
-        | [| "build-github-dot-project" |] -> buildGitHubDotNet()
-        | [| "build-github-fable" |] -> buildGitHubFable()
+        | [| "build-github" |] -> buildGithub()
+        | [| "build-github-dot-project" |] -> buildGithubDotNet()
+        | [| "build-github-fable" |] -> buildGithubFable()
         | [| "clear" |] -> clear()
         | _ -> printfn "Unknown args %A" args
         0

--- a/build/Snowflaqe.Build.fsproj
+++ b/build/Snowflaqe.Build.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fake.Core.Environment" Version="5.20.4" />
-    <PackageReference Include="Fake.Core.Target" Version="5.20.4" />
+    <PackageReference Include="Fake.Core.Environment" Version="5.23.1" />
+    <PackageReference Include="Fake.Core.Target" Version="5.23.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1" />
+    <PackageReference Update="FSharp.Core" Version="6.0.6" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.400",
+    "rollForward": "latestMinor"
+  }
+}

--- a/samples/github/queries/FilteredSecurityAdvisory.gql
+++ b/samples/github/queries/FilteredSecurityAdvisory.gql
@@ -1,0 +1,14 @@
+query GetSecurityAdvisory($ident:SecurityAdvisoryIdentifierFilter!)  {
+  securityAdvisories(first: 10, identifier: $ident) {
+    nodes {
+      identifiers {
+        value
+      }
+      ghsaId
+      cvss {
+        vectorString
+      }
+      classification
+    }
+  }
+}

--- a/src/CodeGen.fs
+++ b/src/CodeGen.fs
@@ -364,7 +364,10 @@ let createGlobalTypes (schema: GraphqlSchema) (normalizeEnumCases: bool) =
     let enums =
         schema.types
         |> List.choose (function
-            | GraphqlType.Enum enumType when not (enumType.name.StartsWith "__")  -> Some enumType
+            | GraphqlType.Enum ({ values = vs } as enumType)
+                when not (enumType.name.StartsWith "__")
+                && vs |> List.exists (fun v -> not v.deprecated) ->
+                    Some enumType
             | _ -> None)
         |> List.map (fun gqlType -> createEnumType gqlType normalizeEnumCases)
 

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -4,21 +4,24 @@ open System.IO
 open System.Text
 open System.Xml
 open System.Xml.Linq
-open FSharp.Compiler.SyntaxTree
+open FSharp.Compiler.Syntax
 open FSharp.Data.LiteralProviders
 open BlackFox.ColoredPrintf
 open Newtonsoft.Json.Linq
 open Snowflaqe
 open Snowflaqe.Types
 
-let [<Literal>] FableRemotingJsonVersion = "2.18.0"
-let [<Literal>] FableSimpleHttpVersion = "3.0.0"
-let [<Literal>] FableSimpleJsonVersion = "3.21.0"
-let [<Literal>] FSharpCoreVersion = "4.7.2"
-let [<Literal>] FSharpSystemTextJsonVersion = "0.17.4"
-let [<Literal>] NewtonsoftJsonVersion = "12.0.2"
-let [<Literal>] SystemTextJsonVersion = "4.6.0"
-let [<Literal>] SystemNetHttpJsonVersion = "5.0.0"
+
+let [<Literal>] SnowflaqeTasksVersion = "1.4.4"
+let [<Literal>] FantomasFCSVersion = "5.1.3"
+let [<Literal>] FableRemotingJsonVersion = "2.21.0"
+let [<Literal>] FableSimpleHttpVersion = "3.5.0"
+let [<Literal>] FableSimpleJsonVersion = "3.24.0"
+let [<Literal>] FSharpCoreVersion = "6.0.1"
+let [<Literal>] FSharpSystemTextJsonVersion = "1.0.6"
+let [<Literal>] NewtonsoftJsonVersion = "13.0.1"
+let [<Literal>] SystemTextJsonVersion = "6.0.7"
+let [<Literal>] SystemNetHttpJsonVersion = "6.0.0"
 let [<Literal>] PlyVersion = "0.3.1"
 
 type CustomErrorType = {
@@ -467,10 +470,11 @@ let generate (config: Config) =
 
         let packageReferences = [
             if config.generateAndRestoreTaskPackage then
-                yield MSBuildXElement.PackageReferenceInclude("Snowflaqe.Tasks", "1.0.0")
+                yield MSBuildXElement.PackageReferenceInclude("Snowflaqe.Tasks", SnowflaqeTasksVersion)
             // use a low version of FSharp.Core
             // for better compatibility
             yield MSBuildXElement.PackageReferenceUpdate("FSharp.Core", FSharpCoreVersion)
+            // yield MSBuildXElement.PackageReferenceInclude("Fantomas.FCS", FantomasFCSVersion)
         ]
 
         let useTasksForAsync = config.asyncReturnType = AsyncReturnType.Task
@@ -668,6 +672,7 @@ let generate (config: Config) =
                 MSBuildXElement.PackageReferenceUpdate("FSharp.Core", FSharpCoreVersion)
                 MSBuildXElement.PackageReferenceInclude("Fable.SimpleHttp", FableSimpleHttpVersion)
                 MSBuildXElement.PackageReferenceInclude("Fable.SimpleJson", FableSimpleJsonVersion)
+                // MSBuildXElement.PackageReferenceInclude("Fantomas.FCS", FantomasFCSVersion)
             ]
 
             let files =

--- a/src/Snowflaqe.fsproj
+++ b/src/Snowflaqe.fsproj
@@ -7,9 +7,9 @@
     <PackAsTool>true</PackAsTool>
     <IsPackable>true</IsPackable>
     <RollForward>Major</RollForward>
-    <TargetFramework Condition=" '$(IsNuget)' != '' ">net5.0</TargetFramework>
-    <TargetFrameworks Condition=" '$(IsNuget)' == '' ">netstandard2.0; netcoreapp3.1;net5.0</TargetFrameworks>
-    <Version>1.38.0</Version>
+    <TargetFramework Condition=" '$(IsNuget)' != '' ">net6.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(IsNuget)' == '' ">netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <Version>1.39.0</Version>
     <PackageReleaseNotes>Allow parser to read schema from SDL when it contains custom scalar types</PackageReleaseNotes>
     <AutoGenerateBindingRedirects Condition=" '$(IsNuget)' == '' ">true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -31,18 +31,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="6.0.6" />
     <PackageReference Include="BlackFox.ColoredPrintf" Version="1.0.5" />
-    <PackageReference Include="Fantomas" Version="4.5.1" />
-    <PackageReference Include="FsAst" Version="0.10.0" />
-    <PackageReference Include="FSharp.Compiler.Service" Version="39.0.0" />
-    <PackageReference Include="FSharp.Data.LiteralProviders" Version="0.3.5" />
-    <PackageReference Include="GraphQL" Version="5.1.1" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="5.1.1" />
+    <PackageReference Include="Fantomas.Core" Version="5.1.3" />
+    <PackageReference Include="Fantomas.FCS" Version="5.1.3" />
+    <PackageReference Include="FSharp.Data.LiteralProviders" Version="1.0.3" />
+    <PackageReference Include="GraphQL" Version="7.1.1" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="7.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1" />
-  </ItemGroup>
 
 </Project>

--- a/tasks/GenerateGraphQLClient.fs
+++ b/tasks/GenerateGraphQLClient.fs
@@ -83,7 +83,14 @@ type public GenerateGraphQLClient() =
                 | Error code -> code
                 | Ok files ->
                     this.GeneratedFiles <-
-                        files |> Seq.map (fun f -> Path.Combine(config.output, Path.GetFileName(f))) |> Seq.toArray
+                        files
+                        |> Seq.map
+                            (fun f ->
+                                Path.Combine(
+                                    config.output,
+                                    Path.GetFileName(f.Replace(@"\",Path.DirectorySeparatorChar.ToString()))))
+                        |> Seq.toArray
+                    this.GeneratedFiles |> Seq.iter (this.Log.LogMessage)
                     0
             else validationCode
 

--- a/tasks/Snowflaqe.Tasks.fsproj
+++ b/tasks/Snowflaqe.Tasks.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
     <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -11,13 +11,13 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DevelopmentDependency>true</DevelopmentDependency>
     <MinClientVersion>2.8</MinClientVersion>
-    <Version>1.4.3</Version>
+    <Version>1.4.4</Version>
     <PackageReleaseNotes>Allow parser to read schema from SDL when it contains custom scalars</PackageReleaseNotes>
   </PropertyGroup>
 
   <Target Name="PackBuildOutputs" DependsOnTargets="SatelliteDllsProjectOutputGroup;DebugSymbolsProjectOutputGroup">
     <PropertyGroup>
-      <BuildSubDir Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">MSBuildCore\</BuildSubDir>
+      <BuildSubDir Condition=" '$(TargetFramework)' != 'netstandard2.0' ">MSBuildCore\</BuildSubDir>
       <BuildSubDir Condition=" '$(TargetFramework)' == 'netstandard2.0' ">MSBuildFull\</BuildSubDir>
     </PropertyGroup>
     <Error Text="Unrecognized TargetFramework" Condition=" '$(BuildSubDir)' == '' " />
@@ -25,10 +25,9 @@
       <TfmSpecificPackageFile Include="
                               $(OutputPath)Snowflaqe.Tasks.dll*;
                               $(OutputPath)Snowflaqe.dll*;
-                              $(OutputPath)Fantomas.dll*;
-                              $(OutputPath)FsAst.dll*;
+                              $(OutputPath)Fantomas.Core.dll*;
+                              $(OutputPath)Fantomas.FCS.dll*;
                               $(OutputPath)Microsoft.Build.Tasks.Core.dll*;
-                              $(OutputPath)FSharp.Compiler.Service.dll*;
                               $(OutputPath)FSharp.Core.dll*;
                               $(OutputPath)FSharp.Data.LiteralProviders.Runtime.dll*;
                               $(OutputPath)GraphQL.dll*;
@@ -38,7 +37,7 @@
                               $(OutputPath)BlackFox.ColoredPrintf.dll*;
                               $(OutputPath)BlackFox.MasterOfFoo.dll*;
                               $(OutputPath)GraphQL.NewtonsoftJson.dll*;
-                              $(OutputPath)GraphQL-Parser.dll*;
+                              $(OutputPath)GraphQLParser.dll*;
                               ">
         <PackagePath>build\$(BuildSubDir)</PackagePath>
       </TfmSpecificPackageFile>
@@ -68,18 +67,17 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fody" Version="6.5.1">
+    <PackageReference Include="Fody" Version="6.6.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FSharp.Compiler.Service" Version="39.0.0" CopyLocal="true" Publish="false" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" CopyLocal="true" Publish="false" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" CopyLocal="true" Publish="false" />
     <PackageReference Include="ModuleInit.Fody" Version="2.1.*" CopyLocal="false" Publish="false" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Verion="5.0.1" Version="5.0.1">
+    <PackageReference Update="FSharp.Core" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; compile; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -87,18 +85,18 @@
 
   <ItemGroup>
     <!--MSBuild and dependencies only acquired through MSBuild shall not make it into the final package-->
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" CopyLocal="false" Publish="false" />
-    <PackageReference Include="Microsoft.Build.Framework;Microsoft.Build.Utilities.Core" Version="16.10.0" CopyLocal="false" Publish="false" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" CopyLocal="false" Publish="false" />
+    <PackageReference Include="Microsoft.Build.Framework;Microsoft.Build.Utilities.Core" Version="17.3.2" CopyLocal="false" Publish="false" />
     <!--ExcludeAssets="runtime"-->
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" CopyLocal="false" Publish="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" CopyLocal="false" Publish="false" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.4.2244" CopyLocal="false" Publish="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" CopyLocal="false" Publish="false" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" CopyLocal="false" Publish="false" />
   </ItemGroup>
 
   <Target Name="RemoveMicrosoftBuildDllsFromOutput" AfterTargets="ResolveReferences">

--- a/tests/SampleGithubSchema.fs
+++ b/tests/SampleGithubSchema.fs
@@ -5,11 +5,11 @@ open Expecto
 open Snowflaqe
 open Snowflaqe.Types
 
-let [<Literal>] githubSchema = TextFile<"./GitHubSchema.json">.Text
+let [<Literal>] githubSchema = TextFile<"./GithubSchema.json">.Text
 let [<Literal>] typesFileName = "Types.fs"
 
 let queryWithUnion = """
-query GitHubSearch {
+query GithubSearch {
   search(query:"Snowflaqe", type:REPOSITORY, first:10) {
     nodes {
       ... on Repository {
@@ -34,7 +34,7 @@ query GitHubSearch {
 """
 
 let queryWithUnionMissingTypeName = """
-query GitHubSearch {
+query GithubSearch {
   search(query:"Snowflaqe", type:REPOSITORY, first:10) {
     nodes {
       ... on Repository {
@@ -106,7 +106,7 @@ query GetPullRequests($org: String!) {
 }
 """
 
-let githubTests = testList "GitHub tests" [
+let githubTests = testList "Github tests" [
     test "Schema can be parsed" {
         match Schema.parse githubSchema with
         | Error error -> failwith error
@@ -393,7 +393,7 @@ let githubTests = testList "GitHub tests" [
 
             let name =
                 Query.findOperationName query
-                |> Option.defaultValue "GitHubSearch"
+                |> Option.defaultValue "GithubSearch"
                 |> CodeGen.normalizeName
 
             let generated =

--- a/tests/SampleHasuraSchema.fs
+++ b/tests/SampleHasuraSchema.fs
@@ -100,16 +100,20 @@ type userOrderDetails =
 
 /// fetch data from the table: "userOrders"
 type userOrders =
-    { status: string
+    {
+      status: string
       id: int
       deliveryDate: System.DateTimeOffset
       /// An array relationship
-      userOrderDetails: list<userOrderDetails> }
+      userOrderDetails: list<userOrderDetails>
+    }
 
 /// query root
 type Root =
-    { /// fetch data from the table: "userOrders"
-      userOrders: list<userOrders> }
+    { 
+      /// fetch data from the table: "userOrders"
+      userOrders: list<userOrders>
+    }
 
 """
                 Expect.equal (Utilities.trimContentEnd generated) (Utilities.trimContentEnd expected) "The generated code is correct"
@@ -153,16 +157,20 @@ type userOrderDetails =
 
 /// fetch data from the table: "userOrders"
 type userOrders =
-    { status: string
+    {
+      status: string
       id: int
       deliveryDate: System.DateTimeOffset
       /// An array relationship
-      userOrderDetails: list<userOrderDetails> }
+      userOrderDetails: list<userOrderDetails>
+    }
 
 /// query root
 type Root =
-    { /// fetch data from the table: "userOrders"
-      userOrders: list<userOrders> }
+    { 
+      /// fetch data from the table: "userOrders"
+      userOrders: list<userOrders>
+    }
 
 """
                 Expect.equal (Utilities.trimContentEnd generated) (Utilities.trimContentEnd expected) "The generated code correct"
@@ -204,16 +212,20 @@ type userOrderDetails =
 
 /// fetch data from the table: "userOrders"
 type userOrders =
-    { status: string
+    {
+      status: string
       id: int
       deliveryDate: System.DateTimeOffset
       /// An array relationship
-      userOrderDetails: list<userOrderDetails> }
+      userOrderDetails: list<userOrderDetails>
+    }
 
 /// query root
 type Root =
-    { /// fetch data from the table: "userOrders"
-      userOrders: list<userOrders> }
+    {
+      /// fetch data from the table: "userOrders"
+      userOrders: list<userOrders>
+    }
 """
                 Expect.equal (Utilities.trimContentEnd generated) (Utilities.trimContentEnd expected) "The generated code correct"
     }

--- a/tests/SamplePostgraphileSchema.fs
+++ b/tests/SamplePostgraphileSchema.fs
@@ -80,20 +80,24 @@ type AggregatedMeterReading =
 
 /// Reads and enables pagination through a set of `AggregatedMeterReading`.
 type AggregatedMeterReadingsConnection =
-    { /// A list of `AggregatedMeterReading` objects.
-      nodes: list<Option<AggregatedMeterReading>> }
+    {
+      /// A list of `AggregatedMeterReading` objects.
+      nodes: list<Option<AggregatedMeterReading>>
+    }
 
 /// Reads a single `MeterType` that is related to this `Meter`.
 type MeterType = { description: string }
 
 /// Reads a single `Meter` that is related to this `Object`.
 type Meter =
-    { objectId: int
+    {
+      objectId: int
       ean: Option<string>
       importCode: Option<string>
       meterFunction: int
       /// Reads a single `MeterType` that is related to this `Meter`.
-      meterTypeByMeterTypeId: Option<MeterType> }
+      meterTypeByMeterTypeId: Option<MeterType>
+    }
 
 /// Reads a single `ObjectType` that is related to this `Object`.
 type ObjectType =
@@ -102,26 +106,32 @@ type ObjectType =
 
 /// A list of `Object` objects.
 type Object =
-    { name: string
+    {
+      name: string
       path: string
       /// Reads and enables pagination through a set of `AggregatedMeterReading`.
       aggregatedMeterReadingsByObjectId: AggregatedMeterReadingsConnection
       /// Reads a single `Meter` that is related to this `Object`.
       meterByObjectId: Option<Meter>
       /// Reads a single `ObjectType` that is related to this `Object`.
-      objectTypeByObjectTypeId: Option<ObjectType> }
+      objectTypeByObjectTypeId: Option<ObjectType>
+    }
 
 /// Reads and enables pagination through a set of `Object`.
 type ObjectsConnection =
-    { /// The count of *all* `Object` you could get from the connection.
+    {
+      /// The count of *all* `Object` you could get from the connection.
       totalCount: int
       /// A list of `Object` objects.
-      nodes: list<Option<Object>> }
+      nodes: list<Option<Object>>
+    }
 
 /// The root query type which gives access points into the data universe.
 type Root =
-    { /// Reads and enables pagination through a set of `Object`.
-      allObjects: Option<ObjectsConnection> }
+    {
+      /// Reads and enables pagination through a set of `Object`.
+      allObjects: Option<ObjectsConnection>
+    }
 """
                 Expect.equal (Utilities.trimContentEnd generated) (Utilities.trimContentEnd expected) "The generated code is correct"
 

--- a/tests/Snowflaqe.Tests.fsproj
+++ b/tests/Snowflaqe.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="9.0.2" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="5.0.1" />
+    <PackageReference Update="FSharp.Core" Version="6.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi Zaid - Long-time listener (fan), first-time caller (contributor).

Changes to the GitHub GraphQL schema resulted in a couple issue in Snowflaqe generated code, namely:

- when all values in a GraphQL Enum type are marked deprecated, Snowflaqe generated an empty (and therefore invalid) F# Union (see attached Schema doc screenshot)
- when a GraphQL Object field name is an F# keyword/not a valid Record field name (e.g. 'public', 'type', 'base'), Snowflaqe generated the field name as is (and therefore invalid)

![image](https://user-images.githubusercontent.com/20178486/202037986-2aa67199-d818-4453-9b3d-f88419ad2ba1.png) 

```fsharp
///The type of a project item.
[<Fable.Core.StringEnum; RequireQualifiedAccess>]
type ProjectItemType =
    /// Issue
    | [<CompiledName "ISSUE">] Issue
    /// Pull Request
    | [<CompiledName "PULL_REQUEST">] PullRequest
    /// Draft Issue
    | [<CompiledName "DRAFT_ISSUE">] DraftIssue
    /// Redacted Item
    | [<CompiledName "REDACTED">] Redacted

///The type of a project next field.
[<Fable.Core.StringEnum; RequireQualifiedAccess>]
type ProjectNextFieldType =

///Properties by which the return project can be ordered.
[<Fable.Core.StringEnum; RequireQualifiedAccess>]
type ProjectNextOrderField =

///Properties by which project connections can be ordered.
[<Fable.Core.StringEnum; RequireQualifiedAccess>]
type ProjectOrderField =
    /// Order projects by creation time
    | [<CompiledName "CREATED_AT">] CreatedAt
    /// Order projects by update time
    | [<CompiledName "UPDATED_AT">] UpdatedAt
    /// Order projects by name
    | [<CompiledName "NAME">] Name
```

Initially I merely set out to make the minimal updates to address these issues, but I wasn't able to get a working build/development setup with my current dotnet 6 (or 7) SDK setup.

I saw from the previous commit that the simple switch to from net5 to net6 broke CI, so I decided to have a go at getting everything updated for dotnet SDK 6 and Fantomas 5.X.X. A few things made this a bit tricky, in particular the shift in Fantomas to to drop the direct dependency on FCS, swapping it out with the new Fantomas.FCS custom branch. As mentioned in the Readme for that package, it is not binary-compatible which was leading to type mismatches when attempting to get things working with both Fantomas.FCS and FCS loaded concurrently.

Given that all uses of the FCS API in Snowflaqe are eventually passed to Fantomas for rendering, it seemed the easiest route was to drop the direct FCS dependency, instead picking up the FCS assemblies/types from Fantomas.FCS. The current Fantomas.FCS release includes an almost current commit of FCS, which included a large refactoring of the SyntaxTree API, adding ___Trivia types/fields to many Syn types. Those changes required corresponding updates to AstRct/AstCreate helpers from FsAst.

With those changes I was able to get the build/test working, and implement the update/fixes for the GitHub schema. I added some tests for those changes as well, and also adjusted the expected output of a few tests to match the new Fantomas formatting of records with comments on fields.

Appveyor builds (using VS 2022 and Ubuntu images for matrix build, each of which include dotnet 6 SDK) are passing on my branch.

I wasn't sure whether to open separate PRs for just the GitHub schema update/fixes. I have branches for those as well (see git graph) if it makes more sense to start with those, just let me know.

![image](https://user-images.githubusercontent.com/20178486/202038207-682ac432-ccd5-4428-9a95-d3e9d5f263cd.png)

This was my first time really delving into the AST stuff, so some of the routes I with may very well need revising.
