### PR TITLE
Add warning-generating keyword 'params' to reserved keywords list

### DIFF
--- a/src/CodeGen.fs
+++ b/src/CodeGen.fs
@@ -272,7 +272,7 @@ let ensureLegalFieldName (maybeIllegalFieldName: string) =
     let reservedKeywords =
         ["break"; "checked"; "component"; "const"; "constraint"; "continue";
          "event"; "external"; "include"; "mixin"; "parallel"; "process";
-         "protected"; "pure"; "sealed"; "tailcall"; "trait"; "virtual"; "fixed"]
+         "protected"; "pure"; "sealed"; "tailcall"; "trait"; "virtual"; "fixed"; "params"]
 
     let containsReservedKeyword keyword = List.contains keyword reservedKeywords
 


### PR DESCRIPTION
This fixes a warning with some GraphQL type names.
